### PR TITLE
Fix linking when using CMake to privatize internal dependency targets

### DIFF
--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -152,8 +152,9 @@ if(BUILD_LIB)
   target_compile_options(libgmic PRIVATE ${GMIC_CXX_COMPILE_FLAGS} -Dgmic_core)
   set_target_properties(libgmic PROPERTIES SOVERSION "1" OUTPUT_NAME "gmic")
   target_link_libraries(libgmic
-    CImg::CImg
-    GMicStdlib::Stdlib
+    PRIVATE
+      CImg::CImg
+      GMicStdlib::Stdlib
   )
   target_include_directories(libgmic
     PUBLIC
@@ -194,7 +195,12 @@ if(BUILD_CLI)
   add_executable(gmic src/gmic_cli.cpp)
   target_compile_options(gmic PRIVATE ${GMIC_CXX_COMPILE_FLAGS})
   if(ENABLE_DYNAMIC_LINKING)
-    target_link_libraries(gmic libgmic)
+    target_link_libraries(gmic
+      PUBLIC
+        libgmic
+      PRIVATE
+        CImg::CImg
+    )
   else()
     target_link_libraries(gmic libgmicstatic)
   endif()


### PR DESCRIPTION
This fixes building G'MIC and G'MIC-Qt using shared libraries provided by the system along with c-koi/gmic-qt#175

This is inspired by what some other distros (like [Arch](https://github.com/archlinux/svntogit-community/commit/bcae2107711d46a907a4cfea9df8f554d7215525#diff-b4e0d3e268103416850d254758e2ef9045e3e4ab4bd6f384287176977bebf233)) are doing