### PR TITLE
on branch fixabout:

### DIFF
--- a/src/gmic_stdlib.gmic
+++ b/src/gmic_stdlib.gmic
@@ -39341,8 +39341,8 @@ _gui_download_all_data :
 #@gui : "}
 #@gui : sep = separator()
 #@gui : url = link(0,"[1] G'MIC reference documentation","https://gmic.eu/reference/")
-#@gui : url = link(0,"[2] G'MIC scripting tutorial","https://gmic.eu/tutorial/index.shtml")
-#@gui : url = link(0,"[3] G'MIC filter template","https://gmic.eu/template.gmic")
+#@gui : url = link(0,"[2] G'MIC scripting tutorial","https://gmic.eu/tutorial/")
+#@gui : url = link(0,"[3] G'MIC filter template","https://github.com/GreycLab/gmic-community/blob/master/include/template.gmic")
 
 #@gui Friends Hall of Fame : _none_, fx_friends
 #@gui : note = note{"\n<span foreground="purple" underline="single">Supporters:</span>"}


### PR DESCRIPTION
        The GUI definition for "About =>Filter Design" for gmic-qt
        contains two stale URLs, the tutorial root URL and
        the location of the filter template. This commit
        patches these URLs to current versions.

        modified: gmic/src/gmic_stdlib.gmic