### PR TITLE
Fix typo on setting GMIC_CACHE_PATH

### DIFF
--- a/src/gmic_stdlib.gmic
+++ b/src/gmic_stdlib.gmic
@@ -39115,7 +39115,7 @@ _ovh2stats_versions :
 path_cache :
   if !narg({'$_path_cache'})
     _path_cache=$_path_rc
-    if ['$GMIC_CACHE_PATH']!=0 _patch_cache=$GMIC_CACHE_PATH
+    if ['$GMIC_CACHE_PATH']!=0 _path_cache=$GMIC_CACHE_PATH
     elif !${-is_windows}
       if isdir(['{/$HOME/.cache}']) _path_cache=$HOME/.cache/gmic/
       elif ['$XDG_CACHE_HOME']!=0 _path_cache=$XDG_CACHE_HOME/gmic/


### PR DESCRIPTION
Minor typo fix to allow using the environment variable GMIC_CACHE_PATH, without this the env var is silently ignored as it is set on a never again referenced variable.